### PR TITLE
Add nix home-manager config with ghostty

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777411657,
+        "narHash": "sha256-P7XjzOo8Cbuj5eBSO1LaQ1hOy3ir8rtUB64EFZ6kKiQ=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "af59809e9413ec8adb9597a8636491af356fe525",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }: {
+    homeConfigurations = {
+      "tsukamoto" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+        modules = [ ./nix/home.nix ];
+      };
+    };
+  };
+}

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,4 @@
+theme = Catppuccin Frappe 
+font-family = JetBrains Mono
+font-family = Noto Sans JP
+font-size = 12

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,0 +1,12 @@
+{ pkgs, config, ... }: {
+  home.username = "tsukamoto";
+  home.homeDirectory = "/Users/tsukamoto";
+  home.stateVersion = "24.05";
+
+  home.packages = import ./packages.nix { inherit pkgs; };
+
+  xdg.configFile."ghostty/config".source =
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/ghostty/config";
+
+  programs.home-manager.enable = true;
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,2 @@
+{ pkgs }: with pkgs; [
+]


### PR DESCRIPTION
## Summary

- Add Nix flake (`flake.nix`, `flake.lock`) with home-manager
- Add `nix/home.nix` to manage home directory and packages
- Add `nix/packages.nix` as a package list
- Add `ghostty/config` for Ghostty terminal settings (theme, font) and configure home-manager to symlink it

🤖 Generated with [Claude Code](https://claude.com/claude-code)