### PR TITLE
Add starship and font config via nix home-manager

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1,4 +1,6 @@
 theme = Catppuccin Frappe 
-font-family = JetBrains Mono
-font-family = Noto Sans JP
+font-family = JetBrainsMono Nerd Font Mono
+font-family = Noto Sans Mono CJK JP
+
 font-size = 12
+font-feature = -dlig,-liga,-calt

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -8,5 +8,11 @@
   xdg.configFile."ghostty/config".source =
     config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/ghostty/config";
 
+  xdg.configFile."starship.toml".source =
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/starship.toml";
+
+  home.file."Library/Fonts/JetBrainsMonoNerdFont".source = "${pkgs.nerd-fonts.jetbrains-mono}/share/fonts/truetype/NerdFonts";
+  home.file."Library/Fonts/NotoSansCJK".source = "${pkgs.noto-fonts-cjk-sans}/share/fonts/opentype/noto-cjk";
+
   programs.home-manager.enable = true;
 }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,2 +1,5 @@
 { pkgs }: with pkgs; [
+  starship
+  nerd-fonts.jetbrains-mono
+  noto-fonts-cjk-sans
 ]

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,5 +1,5 @@
 { pkgs }: with pkgs; [
-  starship
   nerd-fonts.jetbrains-mono
   noto-fonts-cjk-sans
+  starship
 ]

--- a/starship.toml
+++ b/starship.toml
@@ -2,38 +2,38 @@
 add_newline = true
 
 # Replace the "❯" symbol in the prompt with "➜"
-[character]                            # The name of the module we are configuring is "character"
-success_symbol = "[➜](bold green)"     # The "success_symbol" segment is being set to "➜" with the color "bold green"
+[character] # The name of the module we are configuring is "character"
+  success_symbol = "[➜](bold green)" # The "success_symbol" segment is being set to "➜" with the color "bold green"
 
-[[battery.display]]  # バッテリー残量が0％〜30％の間は「太字の赤色」スタイルを利用する
-threshold = 30
-style = "bold red"
+[[battery.display]] # バッテリー残量が0％〜30％の間は「太字の赤色」スタイルを利用する
+  threshold = 30
+  style = "bold red"
 
-[[battery.display]]  # バッテリー残量が30％〜80％の間は「太字の赤色」スタイルを利用する
-threshold = 80
-style = "bold yellow"
+[[battery.display]] # バッテリー残量が30％〜80％の間は「太字の赤色」スタイルを利用する
+  threshold = 80
+  style = "bold yellow"
 
-[[battery.display]]  # 80％〜100％
-threshold = 100
-style = "bold green"
+[[battery.display]] # 80％〜100％
+  threshold = 100
+  style = "bold green"
 
 # Disable the package module, hiding it from the prompt completely
 [package]
-disabled = true
+  disabled = true
 
 [directory]
-truncation_symbol = ".../"
+  truncation_symbol = ".../"
 
 [time]
-disabled = false
-format = '🕙 [\[ $time \]]($style) '
-time_format = "%T"
-utc_time_offset = "+9"
+  disabled = false
+  format = '🕙 [\[ $time \]]($style) '
+  time_format = "%R"
+  utc_time_offset = "+9"
 
 [git_branch]
-only_attached = true
+  only_attached = true
 
 [git_status]
-ahead = "⇡${count}"
-diverged = "⇕⇡${ahead_count}⇣${behind_count}"
-behind = "⇣${count}"
+  ahead = "⇡${count}"
+  diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+  behind = "⇣${count}"


### PR DESCRIPTION
## Summary
- Add starship, JetBrainsMono Nerd Font, and Noto Sans CJK to nix packages
- Symlink `starship.toml` to `~/.config/starship.toml` via home-manager for live editing
- Fix `programs.starship.enable` conflict: removed it since shell init is already handled in `zshrc` and config is managed via symlink
- Update ghostty font names to match Nerd Font package naming
- Disable font ligatures in ghostty config

🤖 Generated with [Claude Code](https://claude.com/claude-code)