### PR TITLE
fix(nix): add direnv and update flake.lock for binary cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777411657,
-        "narHash": "sha256-P7XjzOo8Cbuj5eBSO1LaQ1hOy3ir8rtUB64EFZ6kKiQ=",
+        "lastModified": 1778009629,
+        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "af59809e9413ec8adb9597a8636491af356fe525",
+        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777270315,
-        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -6,6 +6,7 @@
   # Shell
   starship
   zsh-autosuggestions
+  direnv
   fzf
 
   # CLI tools


### PR DESCRIPTION
## Summary

- Add direnv to `nix/packages.nix`
- Update `flake.lock` to a nixpkgs revision where direnv is available in the binary cache for aarch64-darwin
- Previous nixpkgs revision (`6368eda`) required building direnv from source (10+ min), new revision (`ed67bc8`) fetches from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)