### PR TITLE
feat(nix): install mise via home-manager

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -10,6 +10,7 @@
   fzf
 
   # CLI tools
+  mise
   git
   git-extras
   tig


### PR DESCRIPTION
Add `mise` to the host package list in `nix/packages.nix` so it is installed via home-manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)