### PR TITLE
feat(nix): install ngrok via home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           config.allowUnfreePredicate = pkg:
             builtins.elem (nixpkgs.lib.getName pkg) [
               "1password-cli"
+              "ngrok"
             ];
         };
         modules = [ ./nix/home.nix ];

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -23,6 +23,7 @@
   gnused
   ninja
   kubectl
+  ngrok
   _1password-cli
 
   # Editor


### PR DESCRIPTION
Add `ngrok` to the host package list in `nix/packages.nix` so it is installed via home-manager.

Since `ngrok` is unfree, also add `"ngrok"` to `allowUnfreePredicate` in `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)