### PR TITLE
Support multiple machines via username parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-hoge
+# dotfiles
+
+Managed with [home-manager](https://github.com/nix-community/home-manager) (flake).
+
+Replace `<username>` below with the target machine's username
+(`homeConfigurations` defined in [flake.nix](flake.nix)).
+
+## Apply
+
+```bash
+nix run home-manager -- switch --flake .#<username>
+```
+
+## Verify without applying
+
+```bash
+nix build --no-link .#homeConfigurations.<username>.activationPackage
+```

--- a/flake.nix
+++ b/flake.nix
@@ -7,19 +7,25 @@
     };
   };
 
-  outputs = { nixpkgs, home-manager, ... }: {
-    homeConfigurations = {
-      "tsukamoto" = home-manager.lib.homeManagerConfiguration {
+  outputs = { nixpkgs, home-manager, ... }:
+    let
+      mkHome = username: home-manager.lib.homeManagerConfiguration {
         pkgs = import nixpkgs {
           system = "aarch64-darwin";
           config.allowUnfreePredicate = pkg:
             builtins.elem (nixpkgs.lib.getName pkg) [
               "1password-cli"
-              "ngrok"
             ];
         };
+        extraSpecialArgs = { inherit username; };
         modules = [ ./nix/home.nix ];
       };
+    in {
+      homeConfigurations = {
+        # private machine
+        "tsukamoto" = mkHome "tsukamoto";
+        # work machine
+        "ttsukamoto" = mkHome "ttsukamoto";
+      };
     };
-  };
 }

--- a/gitconfig
+++ b/gitconfig
@@ -1,11 +1,9 @@
 [core]
     editor = nvim
 
-[includeIf "gitdir:~/git/private/"]
-    path = ~/git/private/gitconfig
-    path = ~/git/private/gitconfig_local
+[user]
+    name = himetani
+    email = 8338435+himetani@users.noreply.github.com
 
-[includeIf "gitdir:~/git/company/"]
-    path = ~/git/company/gitconfig
 [init]
 	defaultBranch = main

--- a/gitconfig-private
+++ b/gitconfig-private
@@ -1,3 +1,0 @@
-[user]
-    name = himetani
-    email = h.s.g.616top@gmail.com

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,8 +1,8 @@
-{ pkgs, config, ... }:
+{ pkgs, config, username, ... }:
 {
   imports = [ ./tmux.nix ];
-  home.username = "tsukamoto";
-  home.homeDirectory = "/Users/tsukamoto";
+  home.username = username;
+  home.homeDirectory = "/Users/${username}";
   home.stateVersion = "24.05";
 
   home.packages = import ./packages.nix { inherit pkgs; };
@@ -15,9 +15,6 @@
 
   home.file.".gitconfig".source =
     config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/gitconfig";
-
-  home.file."git/private/gitconfig".source =
-    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/gitconfig-private";
 
   home.file.".taplo.toml".source =
     config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/git/dotfiles/taplo.toml";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,6 +13,7 @@
   mise
   git
   git-extras
+  gh
   tig
   htop
   tree
@@ -23,7 +24,6 @@
   gnused
   ninja
   kubectl
-  ngrok
   _1password-cli
 
   # Editor


### PR DESCRIPTION
## Summary

- Parametrize `username` in `home.nix` and generate `homeConfigurations` for both private (`tsukamoto`) and work (`ttsukamoto`) machines via a `mkHome` helper in `flake.nix`
- Unify `gitconfig` into a single identity (GitHub noreply) instead of splitting private/company; drop `gitconfig-private` and the per-directory `includeIf` entries
- Add `gh`, remove `ngrok`
- Document apply/verify commands in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)