### PR TITLE
feat(nvim): add Emacs-style cursor movement in insert mode

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -1,3 +1,17 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
+
+-- Emacs-style cursor movement in insert mode.
+-- Note: C-n/C-p fall back here only when the blink.cmp menu is hidden
+-- (see lua/plugins/blink.lua).
+local map = vim.keymap.set
+map("i", "<C-a>", "<Home>", { desc = "Beginning of line" })
+map("i", "<C-e>", "<End>", { desc = "End of line" })
+map("i", "<C-b>", "<Left>", { desc = "Backward char" })
+map("i", "<C-f>", "<Right>", { desc = "Forward char" })
+map("i", "<C-n>", "<Down>", { desc = "Next line" })
+map("i", "<C-p>", "<Up>", { desc = "Previous line" })
+map("i", "<C-d>", "<Del>", { desc = "Delete char forward" })
+map("i", "<M-b>", "<S-Left>", { desc = "Backward word" })
+map("i", "<M-f>", "<S-Right>", { desc = "Forward word" })

--- a/nvim/lua/plugins/blink.lua
+++ b/nvim/lua/plugins/blink.lua
@@ -1,0 +1,12 @@
+return {
+  -- Let C-n/C-p navigate the completion menu only while it is open;
+  -- otherwise fall back to the insert-mode keymaps (Emacs-style line
+  -- movement defined in lua/config/keymaps.lua).
+  "saghen/blink.cmp",
+  opts = {
+    keymap = {
+      ["<C-n>"] = { "select_next", "fallback" },
+      ["<C-p>"] = { "select_prev", "fallback" },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

Add Emacs/readline-style cursor movement keys in Neovim insert mode.

- `C-a` / `C-e`: beginning / end of line
- `C-b` / `C-f`: backward / forward char
- `C-n` / `C-p`: next / previous line
- `C-d`: delete char forward
- `M-b` / `M-f`: backward / forward word

`C-n` / `C-p` are configured in blink.cmp with `{ "select_next/prev", "fallback" }`, so they navigate the completion menu while it is open and fall back to line movement otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)