### PR TITLE
feat(nix): install databricks-cli via home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           config.allowUnfreePredicate = pkg:
             builtins.elem (nixpkgs.lib.getName pkg) [
               "1password-cli"
+              "databricks-cli"
             ];
         };
         extraSpecialArgs = { inherit username; };

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -24,6 +24,7 @@
   gnused
   ninja
   kubectl
+  databricks-cli
   _1password-cli
 
   # Editor


### PR DESCRIPTION
## Summary

Install the Databricks CLI through home-manager.

- Add `databricks-cli` to `nix/packages.nix` (CLI tools).
- Allow its unfree license by adding `databricks-cli` to the `allowUnfreePredicate` list in `flake.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)